### PR TITLE
Generate sqrt, pow, etc. methods

### DIFF
--- a/annotation/src/main/kotlin/org/octogonapus/ktunits/annotation/Quantity.kt
+++ b/annotation/src/main/kotlin/org/octogonapus/ktunits/annotation/Quantity.kt
@@ -199,5 +199,15 @@ inline fun Quantity.log2() = kotlin.math.log2(value)
 @Suppress("NOTHING_TO_INLINE")
 inline fun Quantity.ln1p() = kotlin.math.ln1p(value)
 
+fun Quantity.ceil() = Quantity(massDim, lengthDim, timeDim, angleDim, kotlin.math.ceil(value))
+
+fun Quantity.floor() = Quantity(massDim, lengthDim, timeDim, angleDim, kotlin.math.floor(value))
+
+fun Quantity.truncate() = Quantity(massDim, lengthDim, timeDim, angleDim, kotlin.math.truncate(value))
+
+fun Quantity.round() = Quantity(massDim, lengthDim, timeDim, angleDim, kotlin.math.round(value))
+
+fun Quantity.abs() = Quantity(massDim, lengthDim, timeDim, angleDim, kotlin.math.abs(value))
+
 @Suppress("NOTHING_TO_INLINE")
 inline fun Quantity.sign() = kotlin.math.sign(value)

--- a/annotation/src/main/kotlin/org/octogonapus/ktunits/annotation/Quantity.kt
+++ b/annotation/src/main/kotlin/org/octogonapus/ktunits/annotation/Quantity.kt
@@ -17,12 +17,26 @@
 package org.octogonapus.ktunits.annotation
 
 open class Quantity(
-    val massDim: Long,
-    val lengthDim: Long,
-    val timeDim: Long,
-    val angleDim: Long,
+    val massDim: Double,
+    val lengthDim: Double,
+    val timeDim: Double,
+    val angleDim: Double,
     open val value: Double
 ) {
+
+    constructor(
+        massDim: Number,
+        lengthDim: Number,
+        timeDim: Number,
+        angleDim: Number,
+        value: Number
+    ) : this(
+        massDim = massDim.toDouble(),
+        lengthDim = lengthDim.toDouble(),
+        timeDim = timeDim.toDouble(),
+        angleDim = angleDim.toDouble(),
+        value = value.toDouble()
+    )
 
     fun dimensionsEqual(other: Quantity) =
         massDim == other.massDim && lengthDim == other.lengthDim && timeDim == other.timeDim &&
@@ -156,8 +170,13 @@ inline fun Quantity.acosh() = kotlin.math.acosh(value)
 @Suppress("NOTHING_TO_INLINE")
 inline fun Quantity.atanh() = kotlin.math.atanh(value)
 
-@Suppress("NOTHING_TO_INLINE")
-inline fun Quantity.sqrt() = kotlin.math.sqrt(value)
+fun Quantity.sqrt() = Quantity(
+    massDim / 2,
+    lengthDim / 2,
+    timeDim / 2,
+    angleDim / 2,
+    kotlin.math.sqrt(value)
+)
 
 @Suppress("NOTHING_TO_INLINE")
 inline fun Quantity.exp() = kotlin.math.exp(value)
@@ -179,21 +198,6 @@ inline fun Quantity.log2() = kotlin.math.log2(value)
 
 @Suppress("NOTHING_TO_INLINE")
 inline fun Quantity.ln1p() = kotlin.math.ln1p(value)
-
-@Suppress("NOTHING_TO_INLINE")
-inline fun Quantity.ceil() = kotlin.math.ceil(value)
-
-@Suppress("NOTHING_TO_INLINE")
-inline fun Quantity.floor() = kotlin.math.floor(value)
-
-@Suppress("NOTHING_TO_INLINE")
-inline fun Quantity.truncate() = kotlin.math.truncate(value)
-
-@Suppress("NOTHING_TO_INLINE")
-inline fun Quantity.round() = kotlin.math.round(value)
-
-@Suppress("NOTHING_TO_INLINE")
-inline fun Quantity.abs() = kotlin.math.abs(value)
 
 @Suppress("NOTHING_TO_INLINE")
 inline fun Quantity.sign() = kotlin.math.sign(value)

--- a/annotation/src/main/kotlin/org/octogonapus/ktunits/annotation/Quantity.kt
+++ b/annotation/src/main/kotlin/org/octogonapus/ktunits/annotation/Quantity.kt
@@ -16,6 +16,8 @@
  */
 package org.octogonapus.ktunits.annotation
 
+import kotlin.math.pow
+
 open class Quantity(
     val massDim: Double,
     val lengthDim: Double,
@@ -177,6 +179,16 @@ fun Quantity.sqrt() = Quantity(
     angleDim / 2,
     kotlin.math.sqrt(value)
 )
+
+fun Quantity.pow(exp: Double) = Quantity(
+    massDim * exp,
+    lengthDim * exp,
+    timeDim * exp,
+    angleDim * exp,
+    value.pow(exp)
+)
+
+fun Quantity.pow(exp: Number) = pow(exp.toDouble())
 
 @Suppress("NOTHING_TO_INLINE")
 inline fun Quantity.exp() = kotlin.math.exp(value)

--- a/annotation/src/main/kotlin/org/octogonapus/ktunits/annotation/QuantityType.kt
+++ b/annotation/src/main/kotlin/org/octogonapus/ktunits/annotation/QuantityType.kt
@@ -23,8 +23,8 @@ package org.octogonapus.ktunits.annotation
 @Retention(AnnotationRetention.SOURCE)
 @Target(AnnotationTarget.CLASS)
 annotation class QuantityType(
-    val massDim: Long,
-    val lengthDim: Long,
-    val timeDim: Long,
-    val angleDim: Long
+    val massDim: Double,
+    val lengthDim: Double,
+    val timeDim: Double,
+    val angleDim: Double
 )

--- a/annotation/src/test/kotlin/org/octogonapus/ktunits/annotation/QuantityTest.kt
+++ b/annotation/src/test/kotlin/org/octogonapus/ktunits/annotation/QuantityTest.kt
@@ -37,6 +37,7 @@ import kotlin.math.ln1p
 import kotlin.math.log
 import kotlin.math.log10
 import kotlin.math.log2
+import kotlin.math.pow
 import kotlin.math.round
 import kotlin.math.sign
 import kotlin.math.sin
@@ -178,6 +179,15 @@ internal class QuantityTest {
         assertEquals(
             Quantity(1, 2, 3, 4, sqrt(value)),
             Quantity(2, 4, 6, 8, value).sqrt()
+        )
+    }
+
+    @Test
+    fun `test pow`() {
+        val value = 1.3
+        assertEquals(
+            Quantity(4, 8, 12, 16, value.pow(2)),
+            Quantity(2, 4, 6, 8, value).pow(2)
         )
     }
 

--- a/annotation/src/test/kotlin/org/octogonapus/ktunits/annotation/QuantityTest.kt
+++ b/annotation/src/test/kotlin/org/octogonapus/ktunits/annotation/QuantityTest.kt
@@ -19,26 +19,32 @@ package org.octogonapus.ktunits.annotation
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
+import kotlin.math.abs
 import kotlin.math.acos
 import kotlin.math.acosh
 import kotlin.math.asin
 import kotlin.math.asinh
 import kotlin.math.atan
 import kotlin.math.atanh
+import kotlin.math.ceil
 import kotlin.math.cos
 import kotlin.math.cosh
 import kotlin.math.exp
 import kotlin.math.expm1
+import kotlin.math.floor
 import kotlin.math.ln
 import kotlin.math.ln1p
 import kotlin.math.log
 import kotlin.math.log10
 import kotlin.math.log2
+import kotlin.math.round
 import kotlin.math.sign
 import kotlin.math.sin
 import kotlin.math.sinh
+import kotlin.math.sqrt
 import kotlin.math.tan
 import kotlin.math.tanh
+import kotlin.math.truncate
 
 internal class QuantityTest {
 
@@ -166,11 +172,14 @@ internal class QuantityTest {
         assertEquals(atanh(value), Quantity(0, 0, 0, 0, value).atanh())
     }
 
-    // @Test
-    // fun `test sqrt`() {
-    //     val value = 1.3
-    //     assertEquals(sqrt(value), Quantity(0, 0, 0, 0, value).sqrt())
-    // }
+    @Test
+    fun `test sqrt`() {
+        val value = 1.3
+        assertEquals(
+            Quantity(1, 2, 3, 4, sqrt(value)),
+            Quantity(2, 4, 6, 8, value).sqrt()
+        )
+    }
 
     @Test
     fun `test exp`() {
@@ -215,39 +224,54 @@ internal class QuantityTest {
         assertEquals(ln1p(value), Quantity(0, 0, 0, 0, value).ln1p())
     }
 
-    // @Test
-    // fun `test ceil`() {
-    //     val value = 1.3
-    //     assertEquals(ceil(value), Quantity(0, 0, 0, 0, value).ceil())
-    // }
-    //
-    // @Test
-    // fun `test floor`() {
-    //     val value = 1.3
-    //     assertEquals(floor(value), Quantity(0, 0, 0, 0, value).floor())
-    // }
-    //
-    // @Test
-    // fun `test truncate`() {
-    //     val value = 1.3
-    //     assertEquals(truncate(value), Quantity(0, 0, 0, 0, value).truncate())
-    // }
-    //
-    // @Test
-    // fun `test round`() {
-    //     val value = 1.3
-    //     assertEquals(round(value), Quantity(0, 0, 0, 0, value).round())
-    // }
-    //
-    // @Test
-    // fun `test abs`() {
-    //     val value = 1.3
-    //     assertEquals(abs(value), Quantity(0, 0, 0, 0, value).abs())
-    // }
+    @Test
+    fun `test ceil`() {
+        val value = 1.3
+        assertEquals(
+            Quantity(1, 1, 1, 1, ceil(value)),
+            Quantity(1, 1, 1, 1, value).ceil()
+        )
+    }
+
+    @Test
+    fun `test floor`() {
+        val value = 1.3
+        assertEquals(
+            Quantity(1, 1, 1, 1, floor(value)),
+            Quantity(1, 1, 1, 1, value).floor()
+        )
+    }
+
+    @Test
+    fun `test truncate`() {
+        val value = 1.3
+        assertEquals(
+            Quantity(1, 1, 1, 1, truncate(value)),
+            Quantity(1, 1, 1, 1, value).truncate()
+        )
+    }
+
+    @Test
+    fun `test round`() {
+        val value = 1.3
+        assertEquals(
+            Quantity(1, 1, 1, 1, round(value)),
+            Quantity(1, 1, 1, 1, value).round()
+        )
+    }
+
+    @Test
+    fun `test abs`() {
+        val value = 1.3
+        assertEquals(
+            Quantity(1, 1, 1, 1, abs(value)),
+            Quantity(1, 1, 1, 1, value).abs()
+        )
+    }
 
     @Test
     fun `test sign`() {
         val value = 1.3
-        assertEquals(sign(value), Quantity(0, 0, 0, 0, value).sign())
+        assertEquals(sign(value), Quantity(1, 1, 1, 1, value).sign())
     }
 }

--- a/annotation/src/test/kotlin/org/octogonapus/ktunits/annotation/QuantityTest.kt
+++ b/annotation/src/test/kotlin/org/octogonapus/ktunits/annotation/QuantityTest.kt
@@ -19,32 +19,26 @@ package org.octogonapus.ktunits.annotation
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
-import kotlin.math.abs
 import kotlin.math.acos
 import kotlin.math.acosh
 import kotlin.math.asin
 import kotlin.math.asinh
 import kotlin.math.atan
 import kotlin.math.atanh
-import kotlin.math.ceil
 import kotlin.math.cos
 import kotlin.math.cosh
 import kotlin.math.exp
 import kotlin.math.expm1
-import kotlin.math.floor
 import kotlin.math.ln
 import kotlin.math.ln1p
 import kotlin.math.log
 import kotlin.math.log10
 import kotlin.math.log2
-import kotlin.math.round
 import kotlin.math.sign
 import kotlin.math.sin
 import kotlin.math.sinh
-import kotlin.math.sqrt
 import kotlin.math.tan
 import kotlin.math.tanh
-import kotlin.math.truncate
 
 internal class QuantityTest {
 
@@ -172,11 +166,11 @@ internal class QuantityTest {
         assertEquals(atanh(value), Quantity(0, 0, 0, 0, value).atanh())
     }
 
-    @Test
-    fun `test sqrt`() {
-        val value = 1.3
-        assertEquals(sqrt(value), Quantity(0, 0, 0, 0, value).sqrt())
-    }
+    // @Test
+    // fun `test sqrt`() {
+    //     val value = 1.3
+    //     assertEquals(sqrt(value), Quantity(0, 0, 0, 0, value).sqrt())
+    // }
 
     @Test
     fun `test exp`() {
@@ -221,35 +215,35 @@ internal class QuantityTest {
         assertEquals(ln1p(value), Quantity(0, 0, 0, 0, value).ln1p())
     }
 
-    @Test
-    fun `test ceil`() {
-        val value = 1.3
-        assertEquals(ceil(value), Quantity(0, 0, 0, 0, value).ceil())
-    }
-
-    @Test
-    fun `test floor`() {
-        val value = 1.3
-        assertEquals(floor(value), Quantity(0, 0, 0, 0, value).floor())
-    }
-
-    @Test
-    fun `test truncate`() {
-        val value = 1.3
-        assertEquals(truncate(value), Quantity(0, 0, 0, 0, value).truncate())
-    }
-
-    @Test
-    fun `test round`() {
-        val value = 1.3
-        assertEquals(round(value), Quantity(0, 0, 0, 0, value).round())
-    }
-
-    @Test
-    fun `test abs`() {
-        val value = 1.3
-        assertEquals(abs(value), Quantity(0, 0, 0, 0, value).abs())
-    }
+    // @Test
+    // fun `test ceil`() {
+    //     val value = 1.3
+    //     assertEquals(ceil(value), Quantity(0, 0, 0, 0, value).ceil())
+    // }
+    //
+    // @Test
+    // fun `test floor`() {
+    //     val value = 1.3
+    //     assertEquals(floor(value), Quantity(0, 0, 0, 0, value).floor())
+    // }
+    //
+    // @Test
+    // fun `test truncate`() {
+    //     val value = 1.3
+    //     assertEquals(truncate(value), Quantity(0, 0, 0, 0, value).truncate())
+    // }
+    //
+    // @Test
+    // fun `test round`() {
+    //     val value = 1.3
+    //     assertEquals(round(value), Quantity(0, 0, 0, 0, value).round())
+    // }
+    //
+    // @Test
+    // fun `test abs`() {
+    //     val value = 1.3
+    //     assertEquals(abs(value), Quantity(0, 0, 0, 0, value).abs())
+    // }
 
     @Test
     fun `test sign`() {

--- a/processor/src/main/kotlin/org/octogonapus/ktunits/processor/DimensionData.kt
+++ b/processor/src/main/kotlin/org/octogonapus/ktunits/processor/DimensionData.kt
@@ -20,10 +20,10 @@ import org.octogonapus.ktunits.annotation.QuantityType
 import javax.lang.model.element.Element
 
 internal data class DimensionData(
-    val massDim: Long,
-    val lengthDim: Long,
-    val timeDim: Long,
-    val angleDim: Long
+    val massDim: Double,
+    val lengthDim: Double,
+    val timeDim: Double,
+    val angleDim: Double
 ) {
 
     operator fun plus(other: DimensionData) =
@@ -40,6 +40,22 @@ internal data class DimensionData(
             lengthDim - other.lengthDim,
             timeDim - other.timeDim,
             angleDim - other.angleDim
+        )
+
+    operator fun times(factor: Double) =
+        DimensionData(
+            massDim * factor,
+            lengthDim * factor,
+            timeDim * factor,
+            angleDim * factor
+        )
+
+    operator fun div(denom: Double) =
+        DimensionData(
+            massDim / denom,
+            lengthDim / denom,
+            timeDim / denom,
+            angleDim / denom
         )
 }
 

--- a/processor/src/main/kotlin/org/octogonapus/ktunits/processor/ElementWithDimensions.kt
+++ b/processor/src/main/kotlin/org/octogonapus/ktunits/processor/ElementWithDimensions.kt
@@ -16,12 +16,18 @@
  */
 package org.octogonapus.ktunits.processor
 
+import com.squareup.kotlinpoet.asTypeName
 import javax.lang.model.element.Element
 
 internal data class ElementWithDimensions(
     val element: Element,
     val dimensions: DimensionData
-)
+) {
+
+    val typeName by lazy {
+        element.asType().asTypeName()
+    }
+}
 
 internal fun ElementWithDimensions.isMultiplyCompatible(
     other: ElementWithDimensions,
@@ -36,3 +42,8 @@ internal fun ElementWithDimensions.isDivideCompatible(
 internal fun ElementWithDimensions.isSqrtCompatible(
     other: ElementWithDimensions
 ) = dimensions / 2.0 == other.dimensions
+
+internal fun ElementWithDimensions.isPowCompatible(
+    other: ElementWithDimensions,
+    power: Double
+) = dimensions * power == other.dimensions

--- a/processor/src/main/kotlin/org/octogonapus/ktunits/processor/ElementWithDimensions.kt
+++ b/processor/src/main/kotlin/org/octogonapus/ktunits/processor/ElementWithDimensions.kt
@@ -31,13 +31,13 @@ internal data class ElementWithDimensions(
 
 internal fun ElementWithDimensions.isMultiplyCompatible(
     other: ElementWithDimensions,
-    possibleReturnTypes: List<ElementWithDimensions>
-) = possibleReturnTypes.filter { dimensions + other.dimensions == it.dimensions }
+    possibleReturnType: ElementWithDimensions
+) = dimensions + other.dimensions == possibleReturnType.dimensions
 
 internal fun ElementWithDimensions.isDivideCompatible(
     other: ElementWithDimensions,
-    possibleReturnTypes: List<ElementWithDimensions>
-) = possibleReturnTypes.filter { dimensions - other.dimensions == it.dimensions }
+    possibleReturnType: ElementWithDimensions
+) = dimensions - other.dimensions == possibleReturnType.dimensions
 
 internal fun ElementWithDimensions.isSqrtCompatible(
     other: ElementWithDimensions

--- a/processor/src/main/kotlin/org/octogonapus/ktunits/processor/ElementWithDimensions.kt
+++ b/processor/src/main/kotlin/org/octogonapus/ktunits/processor/ElementWithDimensions.kt
@@ -32,3 +32,7 @@ internal fun ElementWithDimensions.isDivideCompatible(
     other: ElementWithDimensions,
     possibleReturnTypes: List<ElementWithDimensions>
 ) = possibleReturnTypes.filter { dimensions - other.dimensions == it.dimensions }
+
+internal fun ElementWithDimensions.isSqrtCompatible(
+    other: ElementWithDimensions
+) = dimensions / 2.0 == other.dimensions

--- a/processor/src/main/kotlin/org/octogonapus/ktunits/processor/QuantityTypeProcessor.kt
+++ b/processor/src/main/kotlin/org/octogonapus/ktunits/processor/QuantityTypeProcessor.kt
@@ -109,11 +109,22 @@ class QuantityTypeProcessor : AbstractProcessor() {
             conversionFuns?.let { allProperties.addAll(it) }
         }
 
-        // sqrt, ceil, floor, truncate, round, abs
         cartesianProduct.forEach {
             if (it.a.isSqrtCompatible(it.b)) {
                 allFunctions.add(
-                    buildSqrtFun(it.a.element.asType().asTypeName(), it.b.element.asType().asTypeName())
+                    buildSqrtFun(it.a.typeName, it.b.typeName)
+                )
+            }
+
+            if (it.a.isPowCompatible(it.b, 2.0)) {
+                allFunctions.add(
+                    buildSquaredFun(it.a.typeName, it.b.typeName)
+                )
+            }
+
+            if (it.a.isPowCompatible(it.b, 3.0)) {
+                allFunctions.add(
+                    buildCubedFun(it.a.typeName, it.b.typeName)
                 )
             }
         }
@@ -168,9 +179,9 @@ class QuantityTypeProcessor : AbstractProcessor() {
         parameterType: ElementWithDimensions,
         returnType: ElementWithDimensions
     ) = buildMultiplyOrDivideFun(
-        receiverType.element.asType().asTypeName(),
-        parameterType.element.asType().asTypeName(),
-        returnType.element.asType().asTypeName(),
+        receiverType.typeName,
+        parameterType.typeName,
+        returnType.typeName,
         "times",
         '*'
     )
@@ -180,9 +191,9 @@ class QuantityTypeProcessor : AbstractProcessor() {
         parameterType: ElementWithDimensions,
         returnType: ElementWithDimensions
     ) = buildMultiplyOrDivideFun(
-        receiverType.element.asType().asTypeName(),
-        parameterType.element.asType().asTypeName(),
-        returnType.element.asType().asTypeName(),
+        receiverType.typeName,
+        parameterType.typeName,
+        returnType.typeName,
         "div",
         '/'
     )
@@ -236,6 +247,36 @@ class QuantityTypeProcessor : AbstractProcessor() {
         .addStatement(
             """
             |return %T(kotlin.math.sqrt(value))
+            """.trimMargin(),
+            returnType
+        )
+        .build()
+
+    private fun buildSquaredFun(
+        receiverType: TypeName,
+        returnType: TypeName
+    ) = FunSpec.builder("squared")
+        .addModifiers(KModifier.PUBLIC, KModifier.INLINE)
+        .receiver(receiverType)
+        .returns(returnType)
+        .addStatement(
+            """
+            |return %T(Math.pow(value, 2.0))
+            """.trimMargin(),
+            returnType
+        )
+        .build()
+
+    private fun buildCubedFun(
+        receiverType: TypeName,
+        returnType: TypeName
+    ) = FunSpec.builder("cubed")
+        .addModifiers(KModifier.PUBLIC, KModifier.INLINE)
+        .receiver(receiverType)
+        .returns(returnType)
+        .addStatement(
+            """
+            |return %T(Math.pow(value, 3.0))
             """.trimMargin(),
             returnType
         )

--- a/processor/src/main/kotlin/org/octogonapus/ktunits/processor/QuantityTypeProcessor.kt
+++ b/processor/src/main/kotlin/org/octogonapus/ktunits/processor/QuantityTypeProcessor.kt
@@ -77,20 +77,26 @@ class QuantityTypeProcessor : AbstractProcessor() {
         cartesianProduct.forEach {
             // Emitting multiple functions here will cause conflicting declarations, but it helps
             // the user know the root cause
-            it.a.isMultiplyCompatible(it.b, annotatedClassesToDimensions).forEach { returnType ->
-                allFunctions.add(
-                    buildMultiplyFun(it.a, it.b, returnType)
-                )
-            }
-        }
+            annotatedClassesToDimensions.forEach { returnType ->
+                if (it.a.isMultiplyCompatible(it.b, returnType)) {
+                    allFunctions.add(buildMultiplyFun(it.a, it.b, returnType))
+                }
 
-        cartesianProduct.forEach {
-            // Emitting multiple functions here will cause conflicting declarations, but it helps
-            // the user know the root cause
-            it.a.isDivideCompatible(it.b, annotatedClassesToDimensions).forEach { returnType ->
-                allFunctions.add(
-                    buildDivideFun(it.a, it.b, returnType)
-                )
+                if (it.a.isDivideCompatible(it.b, returnType)) {
+                    allFunctions.add(buildDivideFun(it.a, it.b, returnType))
+                }
+            }
+
+            if (it.a.isSqrtCompatible(it.b)) {
+                allFunctions.add(buildSqrtFun(it.a.typeName, it.b.typeName))
+            }
+
+            if (it.a.isPowCompatible(it.b, 2.0)) {
+                allFunctions.add(buildSquaredFun(it.a.typeName, it.b.typeName))
+            }
+
+            if (it.a.isPowCompatible(it.b, 3.0)) {
+                allFunctions.add(buildCubedFun(it.a.typeName, it.b.typeName))
             }
         }
 
@@ -98,44 +104,18 @@ class QuantityTypeProcessor : AbstractProcessor() {
             val typeName = element.asType().asTypeName()
             allFunctions.add(buildPlusFun(typeName))
             allFunctions.add(buildMinusFun(typeName))
-        }
+            allFunctions.add(buildCeilFun(typeName))
+            allFunctions.add(buildFloorFun(typeName))
+            allFunctions.add(buildTruncateFun(typeName))
+            allFunctions.add(buildRoundFun(typeName))
+            allFunctions.add(buildAbsFun(typeName))
 
-        annotatedTypeClasses.forEach { element ->
             val conversions = element.getAnnotation(QuantityConversions::class.java)
             val conversionFuns = conversions?.values?.flatMap {
                 buildConversionFuns(element.asType().asTypeName(), it)
             }
 
             conversionFuns?.let { allProperties.addAll(it) }
-        }
-
-        cartesianProduct.forEach {
-            if (it.a.isSqrtCompatible(it.b)) {
-                allFunctions.add(
-                    buildSqrtFun(it.a.typeName, it.b.typeName)
-                )
-            }
-
-            if (it.a.isPowCompatible(it.b, 2.0)) {
-                allFunctions.add(
-                    buildSquaredFun(it.a.typeName, it.b.typeName)
-                )
-            }
-
-            if (it.a.isPowCompatible(it.b, 3.0)) {
-                allFunctions.add(
-                    buildCubedFun(it.a.typeName, it.b.typeName)
-                )
-            }
-        }
-
-        annotatedTypeClasses.forEach { element ->
-            val typeName = element.asType().asTypeName()
-            allFunctions.add(buildCeilFun(typeName))
-            allFunctions.add(buildFloorFun(typeName))
-            allFunctions.add(buildTruncateFun(typeName))
-            allFunctions.add(buildRoundFun(typeName))
-            allFunctions.add(buildAbsFun(typeName))
         }
 
         val file = File(generatedSourcesRoot)

--- a/processor/src/main/kotlin/org/octogonapus/ktunits/processor/QuantityTypeProcessor.kt
+++ b/processor/src/main/kotlin/org/octogonapus/ktunits/processor/QuantityTypeProcessor.kt
@@ -109,6 +109,15 @@ class QuantityTypeProcessor : AbstractProcessor() {
             conversionFuns?.let { allPropBuilders.addAll(it) }
         }
 
+        // sqrt, ceil, floor, truncate, round, abs
+        cartesianProduct.forEach {
+            if (it.a.isSqrtCompatible(it.b)) {
+                allFunBuilders.add(
+                    buildSqrtFun(it.a.element.asType().asTypeName(), it.b.element.asType().asTypeName())
+                )
+            }
+        }
+
         val file = File(generatedSourcesRoot)
         file.mkdir()
 
@@ -203,6 +212,21 @@ class QuantityTypeProcessor : AbstractProcessor() {
         .addStatement(
             """
             |return %T(value $op other.value)
+            """.trimMargin(),
+            returnType
+        )
+        .build()
+
+    private fun buildSqrtFun(
+        receiverType: TypeName,
+        returnType: TypeName
+    ) = FunSpec.builder("sqrt")
+        .addModifiers(KModifier.PUBLIC, KModifier.INLINE)
+        .receiver(receiverType)
+        .returns(returnType)
+        .addStatement(
+            """
+            |return %T(kotlin.math.sqrt(value))
             """.trimMargin(),
             returnType
         )

--- a/quantities/src/main/kotlin/org/octogonapus/ktunits/quantities/Acceleration.kt
+++ b/quantities/src/main/kotlin/org/octogonapus/ktunits/quantities/Acceleration.kt
@@ -19,7 +19,7 @@ package org.octogonapus.ktunits.quantities
 import org.octogonapus.ktunits.annotation.Quantity
 import org.octogonapus.ktunits.annotation.QuantityType
 
-@QuantityType(0, 1, -2, 0)
+@QuantityType(0.0, 1.0, -2.0, 0.0)
 data class Acceleration(
     override val value: Double
 ) : Quantity(0, 1, -2, 0, value)

--- a/quantities/src/main/kotlin/org/octogonapus/ktunits/quantities/Area.kt
+++ b/quantities/src/main/kotlin/org/octogonapus/ktunits/quantities/Area.kt
@@ -21,7 +21,7 @@ import org.octogonapus.ktunits.annotation.QuantityConversion
 import org.octogonapus.ktunits.annotation.QuantityConversions
 import org.octogonapus.ktunits.annotation.QuantityType
 
-@QuantityType(0, 2, 0, 0)
+@QuantityType(0.0, 2.0, 0.0, 0.0)
 @QuantityConversions(
     QuantityConversion("sqMeter", 1.0),
     QuantityConversion("sqInch", 6.452 * 1e-4),

--- a/quantities/src/main/kotlin/org/octogonapus/ktunits/quantities/Force.kt
+++ b/quantities/src/main/kotlin/org/octogonapus/ktunits/quantities/Force.kt
@@ -21,7 +21,7 @@ import org.octogonapus.ktunits.annotation.QuantityConversion
 import org.octogonapus.ktunits.annotation.QuantityConversions
 import org.octogonapus.ktunits.annotation.QuantityType
 
-@QuantityType(1, 1, -2, 0)
+@QuantityType(1.0, 1.0, -2.0, 0.0)
 @QuantityConversions(
     QuantityConversion("newton", 1.0),
     QuantityConversion("dyn", 1e-5),

--- a/quantities/src/main/kotlin/org/octogonapus/ktunits/quantities/Frequency.kt
+++ b/quantities/src/main/kotlin/org/octogonapus/ktunits/quantities/Frequency.kt
@@ -21,7 +21,7 @@ import org.octogonapus.ktunits.annotation.QuantityConversion
 import org.octogonapus.ktunits.annotation.QuantityConversions
 import org.octogonapus.ktunits.annotation.QuantityType
 
-@QuantityType(0, 0, -1, 0)
+@QuantityType(0.0, 0.0, -1.0, 0.0)
 @QuantityConversions(
     QuantityConversion("hz", 1.0),
     QuantityConversion("kHz", 1e+3)

--- a/quantities/src/main/kotlin/org/octogonapus/ktunits/quantities/Jerk.kt
+++ b/quantities/src/main/kotlin/org/octogonapus/ktunits/quantities/Jerk.kt
@@ -19,7 +19,7 @@ package org.octogonapus.ktunits.quantities
 import org.octogonapus.ktunits.annotation.Quantity
 import org.octogonapus.ktunits.annotation.QuantityType
 
-@QuantityType(0, 1, -3, 0)
+@QuantityType(0.0, 1.0, -3.0, 0.0)
 data class Jerk(
     override val value: Double
 ) : Quantity(0, 1, -3, 0, value)

--- a/quantities/src/main/kotlin/org/octogonapus/ktunits/quantities/Length.kt
+++ b/quantities/src/main/kotlin/org/octogonapus/ktunits/quantities/Length.kt
@@ -21,7 +21,7 @@ import org.octogonapus.ktunits.annotation.QuantityConversion
 import org.octogonapus.ktunits.annotation.QuantityConversions
 import org.octogonapus.ktunits.annotation.QuantityType
 
-@QuantityType(0, 1, 0, 0)
+@QuantityType(0.0, 1.0, 0.0, 0.0)
 @QuantityConversions(
     QuantityConversion("gigameter", 1e+9),
     QuantityConversion("megameter", 1e+6),

--- a/quantities/src/main/kotlin/org/octogonapus/ktunits/quantities/Mass.kt
+++ b/quantities/src/main/kotlin/org/octogonapus/ktunits/quantities/Mass.kt
@@ -21,7 +21,7 @@ import org.octogonapus.ktunits.annotation.QuantityConversion
 import org.octogonapus.ktunits.annotation.QuantityConversions
 import org.octogonapus.ktunits.annotation.QuantityType
 
-@QuantityType(1, 0, 0, 0)
+@QuantityType(1.0, 0.0, 0.0, 0.0)
 @QuantityConversions(
     QuantityConversion("gigagram", 1e+6),
     QuantityConversion("megagram", 1e+3),

--- a/quantities/src/main/kotlin/org/octogonapus/ktunits/quantities/Pressure.kt
+++ b/quantities/src/main/kotlin/org/octogonapus/ktunits/quantities/Pressure.kt
@@ -21,7 +21,7 @@ import org.octogonapus.ktunits.annotation.QuantityConversion
 import org.octogonapus.ktunits.annotation.QuantityConversions
 import org.octogonapus.ktunits.annotation.QuantityType
 
-@QuantityType(1, -1, -2, 0)
+@QuantityType(1.0, -1.0, -2.0, 0.0)
 @QuantityConversions(
     QuantityConversion("pascal", 1.0),
     QuantityConversion("bar", 1e+5),

--- a/quantities/src/main/kotlin/org/octogonapus/ktunits/quantities/Time.kt
+++ b/quantities/src/main/kotlin/org/octogonapus/ktunits/quantities/Time.kt
@@ -21,7 +21,7 @@ import org.octogonapus.ktunits.annotation.QuantityConversion
 import org.octogonapus.ktunits.annotation.QuantityConversions
 import org.octogonapus.ktunits.annotation.QuantityType
 
-@QuantityType(0, 0, 1, 0)
+@QuantityType(0.0, 0.0, 1.0, 0.0)
 @QuantityConversions(
     QuantityConversion("gigasecond", 1e+9),
     QuantityConversion("megasecond", 1e+6),

--- a/quantities/src/main/kotlin/org/octogonapus/ktunits/quantities/Torque.kt
+++ b/quantities/src/main/kotlin/org/octogonapus/ktunits/quantities/Torque.kt
@@ -21,7 +21,7 @@ import org.octogonapus.ktunits.annotation.QuantityConversion
 import org.octogonapus.ktunits.annotation.QuantityConversions
 import org.octogonapus.ktunits.annotation.QuantityType
 
-@QuantityType(1, 2, -2, 0)
+@QuantityType(1.0, 2.0, -2.0, 0.0)
 @QuantityConversions(
     QuantityConversion("nM", 1.0),
     QuantityConversion("kgFM", 0.102),

--- a/quantities/src/main/kotlin/org/octogonapus/ktunits/quantities/Velocity.kt
+++ b/quantities/src/main/kotlin/org/octogonapus/ktunits/quantities/Velocity.kt
@@ -21,7 +21,7 @@ import org.octogonapus.ktunits.annotation.QuantityConversion
 import org.octogonapus.ktunits.annotation.QuantityConversions
 import org.octogonapus.ktunits.annotation.QuantityType
 
-@QuantityType(0, 1, -1, 0)
+@QuantityType(0.0, 1.0, -1.0, 0.0)
 @QuantityConversions(
     QuantityConversion("mps", 1.0),
     QuantityConversion("cmps", 1e-2),

--- a/quantities/src/main/kotlin/org/octogonapus/ktunits/quantities/Volume.kt
+++ b/quantities/src/main/kotlin/org/octogonapus/ktunits/quantities/Volume.kt
@@ -21,7 +21,7 @@ import org.octogonapus.ktunits.annotation.QuantityConversion
 import org.octogonapus.ktunits.annotation.QuantityConversions
 import org.octogonapus.ktunits.annotation.QuantityType
 
-@QuantityType(0, 3, 0, 0)
+@QuantityType(0.0, 3.0, 0.0, 0.0)
 @QuantityConversions(
     QuantityConversion("cubicMeter", 1.0),
     QuantityConversion("cubicCentimeter", 1e-6),


### PR DESCRIPTION
### Description of the Change

This PR adds `sqrt`, `pow`, `ceil`, `floor`, `truncate`, `round`, `abs` methods.

### Motivation

These math functions are used frequently and need to be generated.

### Possible Drawbacks

None.

### Verification Process

Manually verified by looking at the generated code.

### Applicable Issues

Closes #1.
